### PR TITLE
Fix organization count on homepage (issue #20)

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@
               </div>
               <div class="border-x border-neutral-border px-3 dark:border-gray-700">
                 <dd id="stat-orgs" class="text-2xl font-extrabold text-primary dark:text-red-400">-</dd>
-                <dt class="mt-1 text-xs font-medium text-gray-500 dark:text-gray-400">Organizations</dt>
+                <dt class="mt-1 text-xs font-medium text-gray-500 dark:text-gray-400">Domains</dt>
               </div>
               <div>
                 <dd id="stat-reporters" class="text-2xl font-extrabold text-primary dark:text-red-400">-</dd>

--- a/js/app.js
+++ b/js/app.js
@@ -177,8 +177,8 @@ async function loadLeaderboard() {
     renderTopCommenters(document.getElementById("commenters-rows"), data);
     renderTopDomains(document.getElementById("domains-rows"), data);
     if (statBugs) statBugs.textContent = formatNumber(data.total_bugs || 0);
+    if (statOrgs) statOrgs.textContent = formatNumber(data.top_domains?.length || 0);
     if (statReporters) statReporters.textContent = formatNumber(data.leaderboard?.length || 0);
-    if (statOrgs) statOrgs.textContent = formatNumber(data.total_orgs || 0);
   } catch {
     // Fall back to GitHub API (subject to rate limits for unauthenticated calls)
     try {
@@ -240,7 +240,6 @@ async function loadLeaderboardFromAPI(container, statBugs, statOrgs, statReporte
     top_commenters: [],
     top_domains: topDomains,
     total_bugs: issues.filter((i) => !i.pull_request).length,
-    total_orgs: orgs.size,
     updated_at: new Date().toISOString(),
   };
 
@@ -248,8 +247,8 @@ async function loadLeaderboardFromAPI(container, statBugs, statOrgs, statReporte
   renderTopCommenters(document.getElementById("commenters-rows"), data);
   renderTopDomains(document.getElementById("domains-rows"), data);
   if (statBugs) statBugs.textContent = formatNumber(data.total_bugs);
-  if (statOrgs) statOrgs.textContent = formatNumber(data.total_orgs);
-  if (statReporters) statReporters.textContent = formatNumber(leaderboard.length);
+if (statOrgs) statOrgs.textContent = formatNumber(data.top_domains?.length || 0); 
+ if (statReporters) statReporters.textContent = formatNumber(leaderboard.length);
 }
 
 function renderLeaderboard(container, data) {


### PR DESCRIPTION
Fix organization count on homepage

The organizations stat was showing incorrect values because it used the wrong data source.

This update makes the organizations count use the domain count from `top_domains`.

Fixes #20