### PR TITLE
Fix Report Bug links to open safely in a new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
           <i class="fa-solid fa-sun hidden dark:inline-block" aria-hidden="true"></i>
         </button>
         <a
-          href="https://github.com/OWASP-BLT/BLT-Pages/issues/new?template=bug_report.yml"
+          href="https://github.com/OWASP-BLT/BLT-Pages/issues/new?template=bug_report.yml" target="_blank" rel="noopener noreferrer"
           class="hidden rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700 sm:inline-flex"
         >
           <i class="fa-solid fa-bug mr-2" aria-hidden="true"></i>Report Bug
@@ -189,7 +189,7 @@
           <i class="fa-brands fa-github mr-2" aria-hidden="true"></i>GitHub
         </a>
         <a
-          href="https://github.com/OWASP-BLT/BLT-Pages/issues/new?template=bug_report.yml"
+          href="https://github.com/OWASP-BLT/BLT-Pages/issues/new?template=bug_report.yml" target="_blank" rel="noopener noreferrer"
           class="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700"
         >
           <i class="fa-solid fa-bug mr-2" aria-hidden="true"></i>Report Bug
@@ -218,7 +218,7 @@
 
             <div class="mt-8 flex flex-wrap items-center gap-3">
               <a
-                href="https://github.com/OWASP-BLT/BLT-Pages/issues/new?template=bug_report.yml"
+                href="https://github.com/OWASP-BLT/BLT-Pages/issues/new?template=bug_report.yml" target="_blank" rel="noopener noreferrer"
                 class="inline-flex items-center rounded-md bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700"
               >
                 <i class="fa-solid fa-bug mr-2" aria-hidden="true"></i>Start reporting
@@ -362,7 +362,7 @@
 
             <a
               id="report-bug-btn"
-              href="https://github.com/OWASP-BLT/BLT-Pages/issues/new?template=bug_report.yml"
+              href="https://github.com/OWASP-BLT/BLT-Pages/issues/new?template=bug_report.yml" target="_blank" rel="noopener noreferrer"
               class="mt-auto inline-flex items-center justify-center rounded-md bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700"
             >
               <i class="fa-solid fa-arrow-right mr-2" aria-hidden="true"></i>
@@ -479,7 +479,7 @@
             <p id="leaderboard-updated" class="mt-1 text-sm text-gray-500 dark:text-gray-400">Updated Mar 3, 2026</p>
           </div>
           <a
-            href="https://github.com/OWASP-BLT/BLT-Pages/issues/new?template=bug_report.yml"
+            href="https://github.com/OWASP-BLT/BLT-Pages/issues/new?template=bug_report.yml" target="_blank" rel="noopener noreferrer"
             class="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700"
           >
             <i class="fa-solid fa-plus mr-2" aria-hidden="true"></i>Submit report
@@ -593,7 +593,7 @@
         <div>
           <h3 class="mb-3 text-sm font-bold uppercase tracking-wider text-gray-900 dark:text-gray-100">Report</h3>
           <ul class="space-y-2 text-sm font-semibold">
-            <li><a href="https://github.com/OWASP-BLT/BLT-Pages/issues/new?template=bug_report.yml" class="text-red-600 hover:underline dark:text-red-400"><i class="fa-solid fa-bug mr-2" aria-hidden="true"></i>Public bug</a></li>
+            <li><a href="https://github.com/OWASP-BLT/BLT-Pages/issues/new?template=bug_report.yml" target="_blank" rel="noopener noreferrer" target="_blank" rel="noopener noreferrer" class="text-red-600 hover:underline dark:text-red-400"><i class="fa-solid fa-bug mr-2" aria-hidden="true"></i>Public bug</a></li>
             <li><a href="https://zero.owaspblt.org" target="_blank" rel="noopener noreferrer" class="text-red-600 hover:underline dark:text-red-400"><i class="fa-solid fa-shield-halved mr-2" aria-hidden="true"></i>Security vulnerability</a></li>
             <li><a href="https://github.com/OWASP-BLT/BLT-Pages/issues/new?template=bug_report.yml&amp;anonymous=true" target="_blank" rel="noopener noreferrer" class="text-red-600 hover:underline dark:text-red-400"><i class="fa-solid fa-user-secret mr-2" aria-hidden="true"></i>Anonymous route</a></li>
           </ul>


### PR DESCRIPTION
## Summary
This PR standardizes external new-tab link behavior by updating link attributes in the landing page.

Closes #52 

## What changed
- Added `target="_blank"` where needed for external links that should open in a new tab.
- Added `rel="noopener noreferrer"` to external new-tab links for security and privacy.
- Made link behavior consistent across desktop and mobile navigation for **Report Bug**.

## Why
- Prevents reverse-tabnabbing risks by removing opener access.
- Improves privacy by not sending referrer details to external destinations.
- Ensures predictable UX across all **Report Bug** entry points.

## Testing
- Verified **Report Bug** opens in a new tab from top navigation.
- Verified mobile **Report Bug** behavior remains correct.
- Spot-checked other external links for consistent `target`/`rel` usage.

## Checklist
- [x] Security best practice applied for external new-tab links
- [x] Behavior validated manually in browser
- [x] No breaking changes expected 