### PR TITLE
Remove issue_comment trigger to prevent unnecessary workflow runs and bot commits

### DIFF
--- a/.github/workflows/update-and-deploy.yml
+++ b/.github/workflows/update-and-deploy.yml
@@ -13,12 +13,6 @@ on:
       - closed
       - reopened
 
-  # Regenerate when a comment is added or edited on any issue
-  issue_comment:
-    types:
-      - created
-      - edited
-
   # Deploy when code is pushed to main
   push:
     branches:
@@ -39,6 +33,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:


### PR DESCRIPTION
**Summary**

This PR removes the `issue_comment` trigger from the leaderboard workflow and adds a guard condition to prevent the workflow from running on commits created by `github-actions[bot]`.

Previously, every comment on an issue or pull request triggered the workflow. When the workflow ran, it regenerated the leaderboard and committed the updated data back to `main`. That bot commit then triggered the workflow again, resulting in an extra run.

During active discussions or PR reviews, frequent comments could cause multiple workflow runs and repeated commits to `main`.

Example flow before this change:

```
Comment on issue/PR
   → workflow runs
       → leaderboard regenerated
           → bot commit to main
               → second workflow run
```

### Changes in this PR

* Removed the `issue_comment` trigger from the workflow
* Added a job-level guard to skip runs triggered by bot commits:

```yaml
jobs:
  build-and-deploy:
    if: github.actor != 'github-actions[bot]'
```

### Result

* Prevents unnecessary workflow runs caused by bot commits
* Reduces extra commits and deployment noise
* Keeps the leaderboard updated through pushes to `main` and scheduled runs

Closes : #76 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to prevent execution when triggered by automated bot processes, eliminating redundant build and deployment cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->