### PR TITLE
fix: link top domains to gitHub issues filtered by domain label

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -897,7 +897,7 @@ function renderTopDomains(container, data, limit = 0, filter = "") {
       return `<tr class="${rowClass} transition-colors">
         <td class="px-3 py-2 text-center w-10">${rankDisplay}</td>
         <td class="px-3 py-2">
-          <a href="https://${escapeHtml(entry.domain)}"
+        <a href="https://github.com/${BLT_CONFIG.REPO_OWNER}/${BLT_CONFIG.REPO_NAME}/issues?q=is:issue+label:%22domain:%20${encodeURIComponent(entry.domain)}%22"
              target="_blank" rel="noopener noreferrer"
              class="flex items-center gap-2 group min-w-0">
             <img src="${faviconUrl}"


### PR DESCRIPTION
### Description
Fixes: #82 

- Clicking a domain in the Top Domains leaderboard now opens GitHub issues filtered by that domain label, making it easier to view related bug reports.

<img width="2594" height="422" alt="image" src="https://github.com/user-attachments/assets/97852b04-55bd-4c98-aa26-a9e8b00d1084" />

### Note 
I intentionally used the domain: label filter instead of a plain domain text search.
Using is:issue+${entry.domain} returns many unrelated issues where the domain appears in comments, titles, or links (for example github.com returns many results unrelated to reported bugs).

Filtering by label:"domain: <domain>" ensures the results correspond to the domain categorisation used by the leaderboard and avoids inflated results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Domain links in the Top Domains table now redirect to a GitHub issues search filtered by domain labels instead of external domain links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->