### PR TITLE
Feature: Update Footer with Full Social Media Links Using SVG Icons #90

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,20 +246,16 @@
   </symbol>
   <symbol id="fa-slack" viewBox="0 0 24 24">
   <path fill="currentColor" d="M6 13a2 2 0 1 1-2-2h2v2zm1 0h2v6a2 2 0 1 1-2-2v-4zm0-1H1a2 2 0 1 1 2-2h4v2zm1-1V6a2 2 0 1 1 2 2v4H8zm1 0h6a2 2 0 1 1-2 2H9v-2zm0-1V8a2 2 0 1 1 2-2v4H9z"/>
-</symbol>
-
+</symbol
 <symbol id="fa-facebook" viewBox="0 0 24 24">
   <path fill="currentColor" d="M22 12a10 10 0 1 0-11.5 9.9v-7H8v-3h2.5V9.5C10.5 7 12 6 14.2 6c1 0 2 .1 2 .1v2.4h-1.2c-1.2 0-1.6.8-1.6 1.6V12H16l-.5 3h-2.1v7A10 10 0 0 0 22 12z"/>
 </symbol>
-
 <symbol id="fa-linkedin" viewBox="0 0 24 24">
   <path fill="currentColor" d="M4 3a2 2 0 1 0 0 4 2 2 0 0 0 0-4zm-2 7h4v11H2V10zm7 0h4v1.6c.6-1 2-2 4.2-2C20 9.6 22 11.5 22 15v7h-4v-6c0-1.5-.5-2.5-2-2.5s-2 1-2 2.5v6H9V10z"/>
 </symbol>
-
 <symbol id="fa-youtube" viewBox="0 0 24 24">
   <path fill="currentColor" d="M23 7s-.2-1.7-.8-2.5c-.7-.9-1.5-.9-1.9-1C16.6 3 12 3 12 3s-4.6 0-8.3.5c-.5.1-1.2.1-1.9 1C1.2 5.3 1 7 1 7S.8 9 .8 11v2c0 2 .2 4 .2 4s.2 1.7.8 2.5c.7.9 1.7.9 2.2 1C7.4 21 12 21 12 21s4.6 0 8.3-.5c.5-.1 1.5-.1 2.2-1 .6-.8.8-2.5.8-2.5s.2-2 .2-4v-2c0-2-.2-4-.2-4zM10 15V9l6 3-6 3z"/>
 </symbol>
-
 <symbol id="fa-infosec" viewBox="0 0 24 24">
   <path fill="currentColor" d="M12 2l10 4v6c0 5-4 9-10 10C6 21 2 17 2 12V6l10-4zm0 4a4 4 0 100 8 4 4 0 000-8z"/>
 </symbol>
@@ -775,14 +771,13 @@
             <svg class="fa-icon text-lg" aria-hidden="true"><use href="#fa-x-twitter"></use></svg>
           </a>
           <!-- Slack -->
-  <a href="https://owasp.org/slack/invite" target="_blank" rel="noopener noreferrer"
+     <a href="https://owasp.org/slack/invite" target="_blank" rel="noopener noreferrer"
      class="text-gray-400 transition hover:text-primary dark:text-gray-500 dark:hover:text-red-400"
      aria-label="OWASP Slack">
-    <svg class="fa-icon text-lg" aria-hidden="true">
+      <svg class="fa-icon text-lg" aria-hidden="true">
       <use href="#fa-slack"></use>
-    </svg>
-  </a>
-
+        </svg>
+         </a>
   <!-- Facebook -->
   <a href="https://www.facebook.com/OWASPFoundation" target="_blank" rel="noopener noreferrer"
      class="text-gray-400 transition hover:text-primary dark:text-gray-500 dark:hover:text-red-400"
@@ -791,7 +786,6 @@
       <use href="#fa-facebook"></use>
     </svg>
   </a>
-
   <!-- Infosec -->
   <a href="https://infosec.exchange/@owasp" target="_blank" rel="noopener noreferrer"
      class="text-gray-400 transition hover:text-primary dark:text-gray-500 dark:hover:text-red-400"
@@ -800,7 +794,6 @@
       <use href="#fa-infosec"></use>
     </svg>
   </a>
-
   <!-- LinkedIn -->
   <a href="https://www.linkedin.com/company/owasp" target="_blank" rel="noopener noreferrer"
      class="text-gray-400 transition hover:text-primary dark:text-gray-500 dark:hover:text-red-400"
@@ -809,7 +802,6 @@
       <use href="#fa-linkedin"></use>
     </svg>
   </a>
-
   <!-- YouTube -->
   <a href="https://www.youtube.com/user/OWASPGLOBAL" target="_blank" rel="noopener noreferrer"
      class="text-gray-400 transition hover:text-primary dark:text-gray-500 dark:hover:text-red-400"
@@ -818,7 +810,6 @@
       <use href="#fa-youtube"></use>
     </svg>
   </a>
-
         </div>
       </div>
       <p id="homepage-updated" class="mt-3 text-center text-xs text-gray-400 dark:text-gray-500">Last updated: Mar 26, 2026, 9:17 AM UTC &mdash; <a href="https://github.com/OWASP-BLT/BLT-Pages/commit/5dd1d41ff2283dbec0ecea94c5a79869ca2ee6f9" target="_blank" rel="noopener noreferrer" class="hover:underline">5dd1d41</a></p>


### PR DESCRIPTION
### Summary
This PR improves the footer by making it more interactive and complete with all official social media channels. It also enhances UI/UX consistency across light and dark themes.

### Changes Made
- Added full set of social media links:
  - GitHub
  - X (Twitter)
  - Slack
  - Facebook
  - LinkedIn
  - YouTube
  - Infosec Exchange (Mastodon)
  
### UI/UX Improvements
- Better SVG icon visibility in both light and dark modes
- Consistent hover transitions across all SVG icons
- Improved accessibility with proper `aria-label` usage on SVG links
- Cleaner layout for social media section with uniform icon sizing

Screenshot: 

Before : 
![SVG1](https://github.com/user-attachments/assets/105804da-aa1d-4bd9-a7b0-fc98ada3f309)

After: 
![SVG](https://github.com/user-attachments/assets/c0d56508-8c1a-43ac-8d71-e40aa280bfbc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added social media links for Slack, Facebook, LinkedIn, YouTube, and Infosec to the site footer, each showing its platform icon so visitors can more easily find and navigate to those external channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->