### PR TITLE
 paginate GitHub API calls to get correct open/closed bug counts

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -192,18 +192,28 @@ function getLeaderboardData() {
 let currentLeaderboardData = null;
 
 async function loadLeaderboardFromAPI(container, statBugs, statDomains, statReporters, limit = 0) {
-
+  const perPage = 100;
+  const MAX_PAGES = 20;
   const issues = [];
   let page = 1;
-  while (true) {
-    const url = `https://api.github.com/repos/${BLT_CONFIG.REPO_OWNER}/${BLT_CONFIG.REPO_NAME}/issues?state=all&labels=bug&per_page=100&page=${page}`;
+  while (page <= MAX_PAGES) {
+    const url = `https://api.github.com/repos/${BLT_CONFIG.REPO_OWNER}/${BLT_CONFIG.REPO_NAME}/issues?state=all&labels=bug&per_page=${perPage}&page=${page}`;
     const res = await fetch(url, { headers: { Accept: "application/vnd.github+json" } });
+    if (res.status === 403) {
+      console.warn("GitHub API rate limit reached; counts may reflect partial data.");
+      break;
+    }
     if (!res.ok) throw new Error(`GitHub API error ${res.status}`);
-    const page_issues = await res.json();
-    if (!Array.isArray(page_issues) || page_issues.length === 0) break;
-    issues.push(...page_issues);
-    if (page_issues.length < 100) break;
+    const pageIssues = await res.json();
+    if (!Array.isArray(pageIssues) || pageIssues.length === 0) break;
+    issues.push(...pageIssues);
+    const linkHeader = res.headers.get("Link") || "";
+    const hasNextPage = linkHeader.includes('rel="next"');
+    if (!hasNextPage || pageIssues.length < perPage) break;
     page++;
+  }
+  if (page > MAX_PAGES) {
+    console.warn(`Pagination capped at ${MAX_PAGES} pages; counts may be incomplete.`);
   }
 
   // Build counts map

--- a/js/app.js
+++ b/js/app.js
@@ -192,7 +192,7 @@ function getLeaderboardData() {
 let currentLeaderboardData = null;
 
 async function loadLeaderboardFromAPI(container, statBugs, statDomains, statReporters, limit = 0) {
-  // Fetch all pages so open/closed counts are accurate when there are >100 issues
+
   const issues = [];
   let page = 1;
   while (true) {

--- a/js/app.js
+++ b/js/app.js
@@ -192,10 +192,19 @@ function getLeaderboardData() {
 let currentLeaderboardData = null;
 
 async function loadLeaderboardFromAPI(container, statBugs, statDomains, statReporters, limit = 0) {
-  const url = `https://api.github.com/repos/${BLT_CONFIG.REPO_OWNER}/${BLT_CONFIG.REPO_NAME}/issues?state=all&labels=bug&per_page=100`;
-  const res = await fetch(url, { headers: { Accept: "application/vnd.github+json" } });
-  if (!res.ok) throw new Error(`GitHub API error ${res.status}`);
-  const issues = await res.json();
+  // Fetch all pages so open/closed counts are accurate when there are >100 issues
+  const issues = [];
+  let page = 1;
+  while (true) {
+    const url = `https://api.github.com/repos/${BLT_CONFIG.REPO_OWNER}/${BLT_CONFIG.REPO_NAME}/issues?state=all&labels=bug&per_page=100&page=${page}`;
+    const res = await fetch(url, { headers: { Accept: "application/vnd.github+json" } });
+    if (!res.ok) throw new Error(`GitHub API error ${res.status}`);
+    const page_issues = await res.json();
+    if (!Array.isArray(page_issues) || page_issues.length === 0) break;
+    issues.push(...page_issues);
+    if (page_issues.length < 100) break;
+    page++;
+  }
 
   // Build counts map
   const counts = {};


### PR DESCRIPTION
The loadLeaderboardFromAPI function was fetching only the first page (per_page=100) of issues. When the repo has more than 100 bug-labelled issues the open and closed counts were wrong because the remaining pages were never fetched.

Fix: loop through all pages until GitHub returns fewer than 100 results, accumulating every issue before computing counts.

Fixes #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Leaderboard now aggregates across all available pages so totals, reporter counts, domain counts, and open/closed bug tallies reflect the full dataset.
  * Improved reliability when fetching data: the app gracefully stops and logs a warning if API limits are reached or if results are exhausted, with safeguards to prevent excessive fetching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->